### PR TITLE
複数削除機能の実装とテスト追加

### DIFF
--- a/method/docs/tutorial-api.yaml
+++ b/method/docs/tutorial-api.yaml
@@ -52,6 +52,29 @@ paths:
       x-internal: true
       description: Post the necessary fields for the API to create a new content.
     parameters: []
+  /contents/bulk-delete:
+    post:
+      summary: 複数コンテンツの一括削除
+      operationId: delete-multiple-contents
+      tags:
+        - Content
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkDeleteResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkDeleteRequest'
+      x-stoplight:
+        id: bulk-delete-contents
+      x-internal: true
+      description: 指定されたIDの複数コンテンツを一括削除します。
+    parameters: []
   '/contents/{id}':
     parameters:
       - schema:
@@ -180,8 +203,6 @@ components:
     UpdateContentRequest:
       title: UpdateContentRequest
       type: object
-      x-stoplight:
-        id: figu3kp6xbdw3
       x-examples:
         Example 1:
           title: Update Title
@@ -198,6 +219,38 @@ components:
           x-stoplight:
             id: umaunx6atkv6f
           example: Update Body
+    BulkDeleteRequest:
+      title: BulkDeleteRequest
+      type: object
+      x-internal: true
+      required:
+        - ids
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+          description: 削除対象のコンテンツIDの配列
+          example: ["1", "2", "3"]
+    BulkDeleteResponse:
+      title: BulkDeleteResponse
+      type: object
+      x-internal: true
+      properties:
+        deletedCount:
+          type: integer
+          description: 削除されたコンテンツの件数
+          example: 2
+        deletedIds:
+          type: array
+          items:
+            type: integer
+          description: 削除されたコンテンツのIDの配列
+          example: [1, 2]
+        message:
+          type: string
+          description: 削除結果のメッセージ
+          example: "2件のコンテンツを削除しました"
   securitySchemes: {}
 x-internal: true
 tags:

--- a/method/handlers/contents.ts
+++ b/method/handlers/contents.ts
@@ -45,3 +45,26 @@ export const deleteContent = async (id: string) => {
   }
   return await contentRepository.remove(content); /*nullを返却しないためにreturn*/
 }  
+
+export const deleteMultipleContents = async (ids: string[]) => {
+  // IDの配列を数値に変換
+  const numericIds = ids.map(id => Number(id));
+  
+  // 指定されたIDのコンテンツを一括取得
+  const contents = await contentRepository.find({
+    where: numericIds.map(id => ({ id }))
+  });
+  
+  if (contents.length === 0) {
+    return { deletedCount: 0, message: "削除対象のコンテンツが見つかりませんでした" };
+  }
+  
+  // 一括削除を実行
+  const deletedContents = await contentRepository.remove(contents);
+  
+  return {
+    deletedCount: deletedContents.length,
+    deletedIds: deletedContents.map((content: Content) => content.id),
+    message: `${deletedContents.length}件のコンテンツを削除しました`
+  };
+}  

--- a/method/src/index.ts
+++ b/method/src/index.ts
@@ -71,6 +71,23 @@ app.delete("/contents/:id", async (req: express.Request, res: express.Response) 
   }
 });
 
+app.post("/contents/bulk-delete", async (req: express.Request, res: express.Response) => {
+  try {
+    const { ids } = req.body;
+    
+    if (!ids || !Array.isArray(ids) || ids.length === 0) {
+      res.status(400).json({ error: "削除対象のIDが指定されていません" });
+      return;
+    }
+    
+    const result = await contentHandler.deleteMultipleContents(ids);
+    res.status(200).json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send("Internal Server Error");
+  }
+});
+
 AppDataSource.initialize()
   .then(async () => {
     console.log("DB connected");


### PR DESCRIPTION
<!-- GitHub Copilot への依頼事項 :コードレビューを実施してコメントをする際は日本語でお願いします。 -->
## issue
- close #6
- Feature は[こちら](https://github.com/Hisashi-Saeki/saeki-api-tutorial/issues/6)

## 変更内容

- 複数削除機能を追加
- 複数削除機能のテストを作成
- API仕様書修正

## 確認したこと

- [x] 正常系：複数削除ができること
- [x] 異常系：必須パラメータが不足している場合、バリデーションエラーを返すこと
- [x] テストが正常に実行されること

## スクリーンショット

<details><summary>変更内容のスクリーンショット</summary>

[スクリーンショット画像または動画]

</details>

## 補足事項

- 複数削除機能により、効率的なコンテンツ管理が可能になりました

## PR 時のセルフチェック

- [ ] 関数や変数の命名は一目で分かるものになってますか？
- [ ] コメントは適切な量で、誰が見ても分かるコメントになってますか？
- [ ] PR 内容に関するテストは書きましたか？
- [ ] PR 内容に付随する各種ドキュメントは一緒に修正しましたか？
- [ ] Issue の完了の定義は満たせていますか？